### PR TITLE
style(theme): 调整 VPNavScreen 的样式以优化布局 #40

### DIFF
--- a/.vitepress/theme/home.css
+++ b/.vitepress/theme/home.css
@@ -67,6 +67,14 @@
   border-bottom: 2px solid var(--vp-nav-text-color);
 }
 
+/* 覆盖 VPNavScreen 的样式 */
+.VPNavScreen {
+  /* 移除 bottom，让高度由内容撑开 */
+  bottom: auto !important;
+  /* 确保 padding 不影响高度计算 */
+  box-sizing: border-box;
+}
+
 .nav-bar-title {
   font-weight: 600;
   background: linear-gradient(120deg, var(--vp-c-primary), var(--vp-c-primary-light));


### PR DESCRIPTION
移除 bottom 属性，使高度由内容撑开，并确保 box-sizing 不影响高度计算

问题根源：VPNavScreen 的 position: fixed 和 bottom: 0 导致高度无法由子盒子 container 撑开。
解决方案：
移除 bottom: 0，让 VPNavScreen 高度自适应内容。
效果：菜单内容正常显示，点击面包屑按钮后菜单可以弹出。