### PR TITLE
[v1] 活动创建部分可保存草稿

### DIFF
--- a/src/components/event/EventDraftTable.tsx
+++ b/src/components/event/EventDraftTable.tsx
@@ -1,0 +1,60 @@
+import React, { Fragment } from 'react';
+import { Table, Button } from 'antd';
+import type { TableProps } from 'antd';
+import router from 'next/router';
+import { Edit } from 'lucide-react';
+
+interface DataType {
+  title: string;
+  start_time: string;
+  location: string;
+  ID: number;
+}
+
+interface Pagination {
+  current: number;
+  pageSize: number;
+  total: number;
+  onChange: (page: number, pageSize: number) => void;
+}
+
+interface EventDraftTableProps {
+  styles?: { [key: string]: string };
+  status: string;
+  permissions: string[];
+  data: DataType[];
+  pagination: Pagination,
+  loading: boolean;
+}
+
+const EventDraftTable: React.FC<EventDraftTableProps> = ({ styles, status, permissions, data, loading, pagination }) => {
+  const columns: TableProps<DataType>['columns'] = [
+    {
+      title: '活动名称',
+      dataIndex: 'title',
+      key: 'title',
+    },
+    {
+      title: '操作',
+      key: 'action',
+      render: (_, record) => {
+        return (
+          <Button
+            type="text"
+            size="small"
+            icon={<Edit className={styles?.listActionIcon} />}
+            title="编辑活动"
+            onClick={() => router.push(`/events/${record.ID}/edit`)}
+          />
+        )
+      }
+    },
+  ];
+
+  return <Fragment>
+    <h3>已保存的活动草稿</h3>
+    <Table<DataType> columns={columns} dataSource={data} size="small" loading={loading} pagination={pagination} />
+  </Fragment>;
+}
+
+export default EventDraftTable;

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -120,6 +120,41 @@ export const createEvent = async (params: CreateEventParams): Promise<EventResul
   }
 };
 
+export const saveEventDraft = async (params: CreateEventParams): Promise<EventResult> => {
+  try {
+    const body = {
+      title: params.title.trim(),
+      desc: params.description.trim(),
+      event_mode: params.event_mode,
+      location: params.event_mode === '线下活动' ? params.location.trim() : '',
+      link: params.event_mode === '线上活动' ? params.link.trim() : '',
+      start_time: params.start_time,
+      end_time: params.end_time,
+      cover_img: params.cover_img,
+      tags: params.tags ?? [],
+      twitter: params.twitter ?? '',
+      ...(params.max_participants != null && { max_participants: params.max_participants }),
+      ...(params.registration_deadline && { registration_deadline: params.registration_deadline }),
+      ...(typeof params.require_approval === 'boolean' && { require_approval: params.require_approval }),
+      ...(typeof params.allow_waitlist === 'boolean' && { allow_waitlist: params.allow_waitlist }),
+    };
+
+    const response = await apiRequest<EventResult>('/events/draft', 'POST', body);
+
+    if (response.code === 200 && response.data) {
+      return {
+        success: true,
+        message: response.message ?? '保存草稿成功',
+        data: response.data as unknown as Event
+      };
+    }
+
+    return { success: false, message: response.message ?? '保存草稿失败' };
+  } catch (error: any) {
+    console.error('保存草稿异常:', error);
+    return { success: false, message: error?.message ?? '网络错误，请稍后重试' };
+  }
+};
 
 export const updateEvent = async (eventId: string, params: UpdateEventParams): Promise<EventResult> => {
   try {

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -247,6 +247,30 @@ export const getEvents = async (params: GetEventsParams = {}): Promise<EventList
   }
 };
 
+export const getEventDrafts = async (params: GetEventsParams = {}): Promise<EventListResult> => {
+  try {
+    const query = new URLSearchParams();
+
+    query.append('page', (params.page ?? 1).toString());
+    query.append('page_size', (params.page_size ?? 6).toString());
+
+    const response = await apiRequest<EventListResult>(`/events/draft?${query.toString()}`, 'GET');
+
+    if (response.code === 200 && response.data) {
+      return {
+        success: true,
+        message: response.message ?? '获取活动草稿列表成功',
+        data: response.data as unknown as PaginatedEventData
+      };
+    }
+
+    return { success: false, message: response.message ?? '获取活动草稿列表失败' };
+  } catch (error: any) {
+    console.error('获取活动草稿列表异常:', error);
+    return { success: false, message: error?.message ?? '网络错误，请稍后重试' };
+  }
+};
+
 // 获取单个事件详情
 export const getEventById = async (eventId: string): Promise<EventResult> => {
   try {

--- a/src/pages/api/event.ts
+++ b/src/pages/api/event.ts
@@ -156,6 +156,42 @@ export const saveEventDraft = async (params: CreateEventParams): Promise<EventRe
   }
 };
 
+export const updateEventDraft = async (eventId: string, params: UpdateEventParams): Promise<EventResult> => {
+  try {
+    const body = {
+      title: params.title.trim(),
+      desc: params.description.trim(),
+      event_mode: params.event_mode,
+      location: params.event_mode === '线下活动' ? params.location.trim() : '',
+      link: params.event_mode === '线上活动' ? params.link.trim() : '',
+      start_time: params.start_time,
+      end_time: params.end_time,
+      cover_img: params.cover_img,
+      tags: params.tags ?? [],
+      twitter: params.twitter ?? '',
+      ...(params.max_participants != null && { max_participants: params.max_participants }),
+      ...(params.registration_deadline && { registration_deadline: params.registration_deadline }),
+      ...(typeof params.require_approval === 'boolean' && { require_approval: params.require_approval }),
+      ...(typeof params.allow_waitlist === 'boolean' && { allow_waitlist: params.allow_waitlist }),
+    };
+
+    const response = await apiRequest<EventResult>(`/events/draft/${eventId}`, 'PUT', body);
+
+    if (response.code === 200 && response.data) {
+      return {
+        success: true,
+        message: response.message ?? '活动草稿更新成功',
+        data: response.data as unknown as Event
+      };
+    }
+
+    return { success: false, message: response.message ?? '活动草稿更新失败' };
+  } catch (error: any) {
+    console.error('活动草稿更新异常:', error);
+    return { success: false, message: error?.message ?? '网络错误，请稍后重试' };
+  }
+};
+
 export const updateEvent = async (eventId: string, params: UpdateEventParams): Promise<EventResult> => {
   try {
     const body = {

--- a/src/pages/events/[id]/edit.tsx
+++ b/src/pages/events/[id]/edit.tsx
@@ -116,6 +116,7 @@ export default function EditEventPage() {
     [form]
   );
 
+  // 保存草稿的按钮暂时注释了
   const handleSaveDraft = async () => {
     try {
       await form.validateFields(['title']);
@@ -518,7 +519,7 @@ export default function EditEventPage() {
           <Link href="/" className={styles.cancelButton}>
             取消
           </Link>
-          <Button
+          {/* <Button
             className={styles.submitButton}
             loading={isSavingDraft}
             disabled={isSavingDraft}
@@ -526,7 +527,7 @@ export default function EditEventPage() {
           >
             <NotepadTextDashed className={styles.submitIcon} />
             {isSavingDraft ? '保存中...' : '保存草稿'}
-          </Button>
+          </Button> */}
           <Button
             type="primary"
             htmlType="submit"

--- a/src/pages/events/index.module.css
+++ b/src/pages/events/index.module.css
@@ -118,6 +118,16 @@
   align-items: center;
 }
 
+.draftTableSection {
+  max-width: 1200px;
+  margin: 0 auto;
+  margin-bottom: 1.5rem;
+}
+
+.draftTableSection h3 {
+  padding-left: 0.5rem;
+}
+
 /* Search Section */
 .searchSection {
   max-width: 1200px;


### PR DESCRIPTION
完成 #144 前端部分

1. 在活动列表页面添加一个列表，展示登录用户的活动草稿，点击跳转编辑页面
2. 在活动创建页面增加`保存草稿`按钮，点击创建草稿
3. 在活动编辑页面增加`保存草稿`按钮，点击更新草稿 

