### PR TITLE
feat: limit post tags display to 3 with overflow count

### DIFF
--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -696,11 +696,16 @@ export default function PostsList() {
                         </div>
                       )}
                       <div className={styles.postDetailTags}>
-                        {selectedPost.tags.map((tag, index) => (
+                        {selectedPost.tags.slice(0, 3).map((tag, index) => (
                           <span key={index} className={styles.postDetailTag}>
                             {tag}
                           </span>
                         ))}
+                        {selectedPost.tags.length > 3 && (
+                          <span className={styles.postDetailTag}>
+                            +{selectedPost.tags.length - 3}
+                          </span>
+                        )}
                       </div>
                     </div>
                   </div>


### PR DESCRIPTION
# 限制文章标签显示为前3个并显示剩余数量

## 👁️ 预览
<img width="787" height="211" alt="image" src="https://github.com/user-attachments/assets/c1dcc62d-74e4-45a2-a78d-7059ba0ef074" />

## 📋 Summary
- 文章详情页面只显示前3个标签
- 超过3个标签时显示 "+N" 提示剩余数量
- 优化多标签文章的界面显示效果