### PR TITLE
feat: add uniform height to event titles with 2-line ellipsis

### DIFF
--- a/src/pages/events/index.module.css
+++ b/src/pages/events/index.module.css
@@ -1,7 +1,7 @@
 .container {
   min-height: 100vh;
   padding: 0rem 1rem;
-  padding-top: 6.5rem; 
+  padding-top: 6.5rem;
   background: linear-gradient(to bottom right, #faf5ff, #e1dbfe);
 }
 
@@ -648,6 +648,9 @@
   overflow: hidden !important;
   flex: 1;
   margin-right: 0.75rem;
+  /* 固定高度确保统一 */
+  height: 3.5rem; /* 1.25rem * 1.4 * 2 = 3.5rem (两行高度) */
+  min-height: 3.5rem;
 }
 
 .menuButton {


### PR DESCRIPTION
# feat: 统一事件标题高度并保持两行省略号显示 #198 

## 👁️ 预览
<img width="1348" height="475" alt="image" src="https://github.com/user-attachments/assets/acf4e63d-451b-4da9-94c2-2d74e440a593" />

## 📝 主要变更
- 为 .eventTitle 添加固定高度 3.5rem 确保布局一致
- 保持现有的两行文本截断和省略号功能
- 根据字体大小和行高计算统一高度
- 提升事件卡片的视觉一致性