### PR TITLE
feat: unify purple theme, display like/favorite counts, standardize interaction buttons

### DIFF
--- a/src/pages/api/post.ts
+++ b/src/pages/api/post.ts
@@ -19,6 +19,8 @@ export interface Post {
   user?: User;
   CreatedAt: string;
   UpdatedAt: string;
+  favorite_count: number; 
+  like_count: number;
 }
 
 // 创建帖子参数

--- a/src/pages/posts/index.module.css
+++ b/src/pages/posts/index.module.css
@@ -386,7 +386,7 @@
 
 .interactionBtn:hover {
     background: rgba(107, 114, 128, 0.1);
-    color: #374151;
+    color: inherit;
     transform: none;
 }
 
@@ -396,7 +396,7 @@
 
 .interactionBtn.liked:hover {
     background: rgba(139, 92, 246, 0.12);
-    color: #8b5cf6;
+    color: #8b5cf6 !important;
 }
 
 .interactionBtn.bookmarked {
@@ -405,7 +405,7 @@
 
 .interactionBtn.bookmarked:hover {
     background: rgba(139, 92, 246, 0.12);
-    color: #8b5cf6;
+    color: #8b5cf6 !important;
 }
 
 /* 游客状态按钮样式 */

--- a/src/pages/posts/index.module.css
+++ b/src/pages/posts/index.module.css
@@ -286,19 +286,19 @@
     gap: 0.375rem;
     padding: 0.375rem 0.75rem;
     border-radius: 16px;
-    color: #6b7280;
+    color: #8b5cf6;
     transition: all 0.2s ease;
     text-decoration: none;
     font-size: 0.75rem;
     font-weight: 500;
-    border: 1px solid #e5e7eb;
-    background: white;
+    border: 1px solid #8b5cf6;
+    background: transparent;
 }
 
 .twitterLink:hover {
-    background: rgba(139, 92, 246, 0.1);
-    color: #8b5cf6;
-    border-color: rgba(139, 92, 246, 0.3);
+    background-color: #8b5cf6;
+    color: #ffffff;
+    border-color: #8b5cf6;
 }
 
 .twitterText {
@@ -391,21 +391,21 @@
 }
 
 .interactionBtn.liked {
-    color: #dc2626;
+    color: #8b5cf6;
 }
 
 .interactionBtn.liked:hover {
-    background: rgba(220, 38, 38, 0.1);
-    color: #dc2626;
+    background: rgba(139, 92, 246, 0.12);
+    color: #8b5cf6;
 }
 
 .interactionBtn.bookmarked {
-    color: #d97706;
+    color: #8b5cf6;
 }
 
 .interactionBtn.bookmarked:hover {
-    background: rgba(217, 119, 6, 0.1);
-    color: #d97706;
+    background: rgba(139, 92, 246, 0.12);
+    color: #8b5cf6;
 }
 
 /* 游客状态按钮样式 */


### PR DESCRIPTION
# feat(posts): 统一主题紫色样式并展示点赞/收藏数，统一右下角交互按钮结构 #191 

## 📺  预览
<img width="904" height="317" alt="image" src="https://github.com/user-attachments/assets/2bd8c49f-49fe-40f8-8f1f-1bd4c1191f02" />

## 📝 主要变更
1. 将列表卡片「查看推文」按钮样式与详情页对齐（紫色描边+紫色文字，hover 填充紫色）。
点赞、收藏的激活态和 hover 统一为主题紫色。
2. 列表页展示 `like_count`、`favorite_count`，并在交互时对计数做乐观更新（失败回滚）。

## 🐛 目前 bug
- `/posts/` 接口返回的 `like_count` 和 `favorite_count` 始终为 0，与 `/posts/status` 返回的数据不一致
 **导致用户点赞后刷新页面时，点赞图标显示为紫色（已点赞状态），但点赞数量仍显示为 0**
 
<img width="907" height="314" alt="image" src="https://github.com/user-attachments/assets/d54f92de-2c45-4c2a-ae01-124db102e5fe" />
