### PR TITLE
feat: Add pagination to pages 

### DIFF
--- a/src/pages/blogs/index.module.css
+++ b/src/pages/blogs/index.module.css
@@ -258,14 +258,9 @@
   box-shadow: 0 1px 3px rgba(99, 102, 241, 0.3);
 }
 
-.resultsInfo {
-  font-size: 0.875rem;
-  color: #6b7280;
-}
-
 .resultInfo {
   font-size: 0.875rem;
-  color: #666;
+  color: #6b7280;
 }
 
 /* Loading */

--- a/src/pages/blogs/index.tsx
+++ b/src/pages/blogs/index.tsx
@@ -221,7 +221,16 @@ export default function BlogsPage() {
           </button>
         </div>
         <div className={styles.resultsInfo}>
-          显示 {startIndex}-{endIndex} 项，共 {total} 项
+          <Pagination
+            current={currentPage}
+            total={total}
+            pageSize={pageSize}
+            onChange={handlePageChange}
+            showTotal={(total, range) =>
+              `显示 ${startIndex}-${endIndex} 项，共 ${total} 项`
+            }
+            className={styles.fullPagination}
+          />
         </div>
       </div>
 

--- a/src/pages/events/index.module.css
+++ b/src/pages/events/index.module.css
@@ -273,11 +273,6 @@
   color: #6b7280;
 }
 
-.resultInfo {
-  font-size: 0.875rem;
-  color: #666;
-}
-
 /* Loading */
 .loading {
   max-width: 1200px;

--- a/src/pages/events/index.tsx
+++ b/src/pages/events/index.tsx
@@ -456,7 +456,16 @@ export default function EventsPage() {
           </button>
         </div>
         <div className={styles.resultsInfo}>
-          显示 {startIndex}-{endIndex} 项，共 {total} 项
+          <Pagination
+            current={currentPage}
+            total={total}
+            pageSize={pageSize}
+            onChange={handlePageChange}
+            showTotal={(total, range) =>
+              `显示 ${startIndex}-${endIndex} 项，共 ${total} 项`
+            }
+            className={styles.fullPagination}
+          />
         </div>
       </div>
 


### PR DESCRIPTION
This PR fixes #196 by:

- Adding a full pagination control to the top of the blog and events index so users can navigate pages and see item counts from both ends of the list

- Cleaned up the corresponding stylesheet by removing the unused resultsInfo rule

You can see the code implemented here:
- [Blogs](https://gmonad-lpvdnab71-iamjustin.vercel.app/blogs)
- [Events](https://gmonad-lpvdnab71-iamjustin.vercel.app/events)