### PR TITLE
feat: Add truncation to usernames on posts

### DIFF
--- a/src/pages/posts/index.module.css
+++ b/src/pages/posts/index.module.css
@@ -541,10 +541,11 @@
 
 .hotPostAuthor {
     color: #8b5cf6;
-}
-
-.hotPostViews {
-    color: #6b7280;
+    flex: 1;
+    min-width: 0;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
 }
 
 

--- a/src/pages/posts/index.tsx
+++ b/src/pages/posts/index.tsx
@@ -852,10 +852,10 @@ export default function PostsList() {
                         <h4 className={styles.hotPostTitle}>{post.title}</h4>
                         <div className={styles.hotPostMeta}>
                           <span className={styles.hotPostAuthor}>
-                            {post.user?.username}
-                          </span>
-                          <span className={styles.hotPostViews}>
-                            {post.view_count} 浏览
+                            {post.user?.username &&
+                            post.user.username.length > 30
+                              ? `${post.user.username.slice(0, 30)}…`
+                              : post.user?.username}
                           </span>
                         </div>
                       </div>


### PR DESCRIPTION
This fixes #221 with the following changes:

- Removed the view count from the “Hot Posts” sidebar so only the author’s name remains beneath each title
- Enforced a maximum of 30 characters for usernames in Hot Posts, appending an ellipsis when truncated
