### PR TITLE
fix(posts): fix spacing issues

### DIFF
--- a/src/styles/markedContainer.css
+++ b/src/styles/markedContainer.css
@@ -17,6 +17,12 @@
   overflow-wrap: break-word;
 }
 
+/* 模拟一个空行 */
+.prose p.extra-break {
+  height: 1.45em;
+  margin: 0;
+}
+
 .prose h1,
 .prose h2,
 .prose h3,


### PR DESCRIPTION
## 📋 Summary
  解决帖子详情中，多个空格会被合并为一个空格的问题

## 📺 Preview
<img width="776" height="700" alt="image" src="https://github.com/user-attachments/assets/4296a70d-6b35-44dc-8d5b-bfae31029d25" />

## 🔍 Root Cause
markdown 字符串被 [marked](https://github.com/markedjs/marked) 成功渲染为 html 文本后，由于浏览器会将多个空格默认合成一个，所以会导致多个空格显示一个空格的问题。

## ✅ Solution
- 使用 `white-space: pre-wrap` 保留文本中的多个空格
- 使用 `display: flex` 解决 `white-space: pre-wrap` 将块级标签比如 `<p>` 的之间换行符渲染为可见的空行的问题。