### PR TITLE
refactor(blogs): consolidate meta information into compact inline format

### DIFF
--- a/src/pages/blogs/[id]/index.module.css
+++ b/src/pages/blogs/[id]/index.module.css
@@ -70,7 +70,7 @@
 .hero {
   background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
   color: white;
-  padding: 3rem 0;
+  padding: 2.5rem 0;
 }
 
 .heroContent {
@@ -78,7 +78,7 @@
   margin: 0 auto;
   padding: 0 1rem;
   display: grid;
-  grid-template-columns: 1fr 400px;
+  grid-template-columns: 1fr 350px;
   gap: 3rem;
   align-items: center;
 }
@@ -86,7 +86,7 @@
 .heroLeft {
   display: flex;
   flex-direction: column;
-  gap: 1.5rem;
+  gap: 1rem;
 }
 
 .statusBadge {
@@ -125,9 +125,10 @@
 
 .description {
   font-size: 1.2rem;
-  font-weight: 700;
-  line-height: 1.2;
+  font-weight: 600;
+  line-height: 1.4;
   margin: 0;
+  color: rgba(255, 255, 255, 0.8) !important;
 }
 
 .sourceLinkButton {
@@ -149,40 +150,6 @@
   background: rgba(255, 255, 255, 0.08);
   border-color: rgba(255, 255, 255, 0.4);
   color: white;
-}
-
-.metaInfo {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-}
-
-.metaItem {
-  display: flex;
-  align-items: flex-start;
-  height: 14px;
-  gap: 1rem;
-}
-
-.metaIcon {
-  width: 1.25rem;
-  height: 1.25rem;
-  margin-top: 0.125rem;
-  flex-shrink: 0;
-  opacity: 0.9;
-}
-
-.metaText {
-  font-size: 1rem;
-  font-weight: 600;
-  line-height: 1.4;
-  margin-top: 2px;
-}
-
-.metaSubtext {
-  font-size: 0.875rem;
-  opacity: 0.8;
-  line-height: 1.4;
 }
 
 .tags {
@@ -211,8 +178,8 @@
   overflow: hidden;
   box-shadow: 0 20px 25px -5px rgba(0, 0, 0, 0.3);
   background: white;
-  height: 300px;
-  width: 400px;
+  height: 220px;
+  width: 350px;
   /* padding: 2px; */
 }
 
@@ -228,6 +195,30 @@
   max-width: 1200px;
   margin: 0 auto;
   padding: 3rem 1rem;
+}
+
+/* 文章元信息 */
+.articleMeta {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+  font-size: 0.875rem;
+  color: rgba(107, 114, 128, 0.8);
+  margin: 0 0 2rem 0;
+  padding-bottom: 1.5rem;
+  border-bottom: 1px solid rgba(229, 231, 235, 0.5);
+}
+
+.metaSeparator {
+  color: rgba(107, 114, 128, 0.5);
+  margin: 0 0.25rem;
+}
+
+.viewCount {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .content {
@@ -902,6 +893,11 @@
     padding: 2rem 1rem;
   }
 
+  .articleMeta {
+    font-size: 0.8125rem;
+    gap: 0.375rem;
+  }
+
   .section {
     padding: 1.5rem;
   }
@@ -934,14 +930,6 @@
 
   .headerActions {
     justify-content: center;
-  }
-
-  .metaInfo {
-    gap: 0.75rem;
-  }
-
-  .metaItem {
-    gap: 0.75rem;
   }
 
   .section {

--- a/src/pages/blogs/[id]/index.tsx
+++ b/src/pages/blogs/[id]/index.tsx
@@ -3,11 +3,9 @@ import { useRouter } from 'next/router';
 import { Button, Tag, App as AntdApp, Image } from 'antd';
 import {
   ArrowLeft,
-  Calendar,
   CheckCircle,
   Edit,
   Eye,
-  User,
 } from 'lucide-react';
 import Link from 'next/link';
 import styles from './index.module.css';
@@ -166,46 +164,13 @@ export default function BlogDetailPage() {
               </a>
             )}
 
-            <div className={styles.metaInfo}>
-              <div className={styles.metaItem}>
-                <Calendar className={styles.metaIcon} />
-                <div className={styles.metaText}>
-                  发布时间：{formatTime(blog.publish_time || blog.CreatedAt)}
-                </div>
-              </div>
-              <div className={styles.metaItem}>
-                <User className={styles.metaIcon} />
-                <div className={styles.metaText}>
-                  作者：{blog.author || blog.publisher?.username || ''}
-                </div>
-              </div>
-              {blog.translator && (
-                  <div className={styles.metaItem}>
-                    <User className={styles.metaIcon} />
-                    <div className={styles.metaText}>
-                      译者：{blog.translator}
-                    </div>
-                  </div>
-              )}
-              <div className={styles.metaItem}>
-                <User className={styles.metaIcon} />
-                <div className={styles.metaText}>
-                  发布者：{blog.publisher?.username || ''}
-                </div>
-              </div>
-              <div className={styles.metaItem}>
-                <Eye className={styles.metaIcon} />
-                <div className={styles.metaText}>
-                  浏览量：{blog.view_count || '0'}
-                </div>
-              </div>
-              <div className={styles.tags}>
-                {blog.tags.map((tag: string, index: number) => (
-                  <Tag key={index} className={styles.tag}>
-                    {tag}
-                  </Tag>
-                ))}
-              </div>
+            {/* 标签 */}
+            <div className={styles.tags}>
+              {blog.tags.map((tag: string, index: number) => (
+                <Tag key={index} className={styles.tag}>
+                  {tag}
+                </Tag>
+              ))}
             </div>
           </div>
 
@@ -214,8 +179,8 @@ export default function BlogDetailPage() {
               <Image
                 src={blog.cover_img || '/placeholder.svg'}
                 alt={blog.title}
-                width={400}
-                height={300}
+                width={350}
+                height={220}
                 className={styles.coverImage}
                 style={{ objectFit: 'cover' }}
               />
@@ -226,6 +191,24 @@ export default function BlogDetailPage() {
 
       <div className={styles.main}>
         <div className="marked-paper">
+          {/* 元信息 */}
+          <div className={styles.articleMeta}>
+            <span>{blog.author || blog.publisher?.username || ''}</span>
+            <span className={styles.metaSeparator}>·</span>
+            <span>{formatTime(blog.publish_time || blog.CreatedAt)}</span>
+            {blog.translator && (
+              <>
+                <span className={styles.metaSeparator}>·</span>
+                <span>译者：{blog.translator}</span>
+              </>
+            )}
+            <span className={styles.metaSeparator}>·</span>
+            <span className={styles.viewCount}>
+              <Eye size={14} />
+              {blog.view_count || '0'}
+            </span>
+          </div>
+
           {/* <h2 className={styles.sectionTitle}>{blog.title}</h2> */}
           <div
             className="prose"


### PR DESCRIPTION
📋 Summary

优化文章详情页的排版与视觉层级，使结构更清晰、信息更集中、阅读体验更舒适。

📺 Preview

**Before**:
<img width="1916" height="968" alt="image" src="https://github.com/user-attachments/assets/6097c344-f4fd-4c4b-a65d-5bb2603cd48f" />
**Now**:
<img width="1917" height="968" alt="image" src="https://github.com/user-attachments/assets/ec65f36a-b325-4ca0-ae01-4693611d965e" />

✅ Improvements

本次优化重点包括以下内容：

1. 调整 Meta 信息布局
- 将作者、时间、译者、浏览量统一放在一行
- 使用更均匀的间距与点间隔符提升可读性
- 提升整体信息密度，减少首屏空间占用

2. 调整文字对比度与层级
- 副标题颜色轻微调暗，避免与主标题争抢视觉焦点
- Meta 信息降低不透明度，强化视觉层级
- 阅读内容部分保持舒适对比度，提高阅读体验
3. 优化首屏信息结构
- 按照「标题 → 副标题 → CTA → Meta」的自然阅读顺序重新排列
- 减少信息散乱与视觉跳跃
- 更符合现代博客风格（如 Medium、Mirror）